### PR TITLE
regc: add a field-info function to search by field

### DIFF
--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -17,5 +17,5 @@ cargo fmt -- --check
 cargo clippy --all-targets -- --deny warnings
 
 banner "test"
-cargo install cargo-nextest
+cargo install cargo-nextest --locked
 cargo nextest run --features test_generated

--- a/lib/src/rust_codegen.rs
+++ b/lib/src/rust_codegen.rs
@@ -495,7 +495,7 @@ impl Visitor for CodegenVisitor {
         });
 
         let mut elements = block.elements.clone();
-        elements.sort_by(|a, b| a.offset.value.cmp(&b.offset.value));
+        elements.sort_by_key(|a| a.offset.value);
         for (idx, element) in elements.iter().enumerate() {
             let doc = element.doc.join("\n");
             let mut tokens = self


### PR DESCRIPTION
Let's you do

```
regc spec.rsf field-info <name>
```

and shows all register definitions that have a field `<name>`